### PR TITLE
Add support for raw and min/max in custom screen definitions

### DIFF
--- a/src/lib/variants/screen.ts
+++ b/src/lib/variants/screen.ts
@@ -1,27 +1,45 @@
 import { Style } from "../../utils/style";
+import { isString } from "../../utils/helpers";
+
+type RawBreakpoint = { raw: string }
+type MinMaxBreakpoint = { min?: string, max?: string }
+type ScreenBreakpoint = RawBreakpoint | MinMaxBreakpoint
 
 export default function generateScreens(screens: {
-  [key: string]: string;
+  [key: string]: string | ScreenBreakpoint;
 }): { [key: string]: () => Style } {
   const variants: { [key: string]: () => Style } = {};
-  const identifiers = Object.keys(screens).sort((a: string, b: string) => {
-    return parseInt(screens[a]) - parseInt(screens[b]);
-  });
 
-  identifiers.forEach((key, index) => {
-    const size = screens[key];
-    variants[key] = () => new Style().atRule(`@media (min-width: ${size})`);
-    variants["-" + key] = () =>
-      new Style().atRule(`@media (max-width: ${size})`);
-    variants["+" + key] = () =>
-      new Style().atRule(
-        identifiers[index + 1]
-          ? `@media (min-width: ${size}) and (max-width: ${
-              screens[identifiers[index + 1]]
-            })`
-          : `@media (min-width: ${size})`
-      );
+  const breakpoints = Object.entries(screens).sort(([, sizeA], [, sizeB]) =>
+    sortWeight(sizeA) - sortWeight(sizeB)
+  );
+
+  breakpoints.forEach(([name, size], index) => {
+    if (isString(size)) {
+      const [, nextSize] = breakpoints[index + 1] || []
+      variants[name] = styleForBreakpoint({ min: size })
+      variants[`-${name}`] = styleForBreakpoint({ max: size })
+      variants[`+${name}`] = styleForBreakpoint(
+        nextSize ? { min: size, max: nextSize as string } : { min: size }
+      )
+    } else {
+      variants[name] = styleForBreakpoint(size)
+    }
   });
 
   return variants;
+}
+
+function styleForBreakpoint(rule: ScreenBreakpoint) {
+  const mediaConditions = 'raw' in rule ? rule.raw : [
+    rule.min && `(min-width: ${rule.min})`,
+    rule.max && `(max-width: ${rule.max})`,
+  ].filter(condition => condition).join(' and ')
+  return () => new Style().atRule(`@media ${mediaConditions}`);
+}
+
+// NOTE: Non-size breakpoints should come first, to avoid using them in the
+// +breakpoint definition.
+function sortWeight(breakpoint: string | ScreenBreakpoint): number {
+  return isString(breakpoint) ? parseInt(breakpoint) : Number.NEGATIVE_INFINITY;
 }

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -2,6 +2,10 @@ import { negateValue } from "./tools";
 import { Property, GlobalStyle } from "./style";
 import type { FontSize } from "../interfaces";
 
+export function isString(value: unknown): value is string {
+  return typeof value === 'string'
+}
+
 export function negative(scale: {
   [key: string]: string;
 }): { [key: string]: string } {

--- a/test/processor/variant.test.ts
+++ b/test/processor/variant.test.ts
@@ -24,8 +24,13 @@ describe("Variants", () => {
     const screens = generateScreens({
       sm: "640px",
       lg: "1024px",
+      print: { raw: "print" },
+      narrow: { max: "768px" },
     });
     expect(_generateTestVariants(screens)).toEqual({
+      print: "@media print {\n  .test {\n    background: #1C1C1E;\n  }\n}",
+      narrow:
+        "@media (max-width: 768px) {\n  .test {\n    background: #1C1C1E;\n  }\n}",
       sm:
         "@media (min-width: 640px) {\n  .test {\n    background: #1C1C1E;\n  }\n}",
       "-sm":
@@ -41,10 +46,14 @@ describe("Variants", () => {
     });
 
     const unsortedScreens = generateScreens({
+      print: { raw: "print" },
       lg: "1024px",
       sm: "640px",
+      narrow: { max: "768px" },
     });
     expect(Object.keys(unsortedScreens)).toEqual([
+      "print",
+      "narrow",
       "sm",
       "-sm",
       "+sm",


### PR DESCRIPTION
### Description 📖 

This pull request adds support for [custom media queries](https://tailwindcss.com/docs/breakpoints#custom-media-queries), [max-width breakpoints](https://tailwindcss.com/docs/breakpoints#max-width-breakpoints), and [multi-range breakpoints](https://tailwindcss.com/docs/breakpoints#multi-range-breakpoints) in the [`screens` configuration option](https://tailwindcss.com/docs/breakpoints).

This way, users that are using these types of breakpoints in `tailwindcss` can easily migrate to `windicss` without changing their configuration or setup.

Added tests that illustrate how the feature works.

Closes #15.