### PR TITLE
fix(stylesheet): sort general utilities first

### DIFF
--- a/src/utils/algorithm/sortSelector.ts
+++ b/src/utils/algorithm/sortSelector.ts
@@ -7,13 +7,19 @@ function getWeights(a: string): number {
     ".": 200,
     "#": 201,
   };
-  if (first === ":" && second === ":") return 59;
-  return first in map ? map[first] : first.charCodeAt(0);
+  if (first === ":" && second === ":")
+    return 59;
+  // utilities with more general prefix should be as lighter weight
+  // e.g. `m-8` < `mt-4`
+  const dashIndex = a.indexOf('-') || 0
+  return first in map
+    ? map[first] + dashIndex
+    : first.charCodeAt(0) + dashIndex;
 }
 
-export default function sortSelector(a: Style, b: Style): 1 | -1 | 0 {
+export default function sortSelector(a: Style, b: Style): number {
   if (a.selector && b.selector) {
-    return getWeights(a.selector) >= getWeights(b.selector) ? 1 : -1;
+    return getWeights(a.selector) - getWeights(b.selector)
   }
   return 0;
 }


### PR DESCRIPTION
When sorting selectors, should make general utilities first.

Currently, utilities with the same leading letter will keep the input order, for example

`mt-8 m-4` will generate as

```css
.mt-8 {
  /* ... */
}

.m-4 {
  /* ... */
}
```

Which causes the `mt-8` been overridden by `m-4`.

This PR makes the sorting for StyleSheets aware of this and always generates `m-4` before `mt-8`. This matches the behavior of TailwindCSS.